### PR TITLE
SLING-10339 temporarily explicitly initialize FSPackageRegistry

### DIFF
--- a/src/main/java/org/apache/sling/jcr/packageinit/impl/ExecutionPlanRepoInitializer.java
+++ b/src/main/java/org/apache/sling/jcr/packageinit/impl/ExecutionPlanRepoInitializer.java
@@ -132,6 +132,9 @@ public class ExecutionPlanRepoInitializer implements SlingRepositoryInitializer 
                 logger.info("Waiting for PackageRegistry.");
                 PackageRegistry registry = (PackageRegistry) st.waitForService(0);
                 logger.info("PackageRegistry found - starting execution of execution plan");
+                // workaround until https://issues.apache.org/jira/browse/JCRVLT-517 is solved: registry.contains yields false value until initialized,
+                // making the call ExecutionPlan.execute() later fail if a new package has a dependency on another package declared
+                registry.packages();
                 
                 ExecutionPlanBuilder builder = registry.createExecutionPlan();
                 @SuppressWarnings("deprecation")

--- a/src/test/java/org/apache/sling/jcr/packageinit/ExecutionPlanRepoInitializerTest.java
+++ b/src/test/java/org/apache/sling/jcr/packageinit/ExecutionPlanRepoInitializerTest.java
@@ -105,8 +105,8 @@ public class ExecutionPlanRepoInitializerTest {
     @Mock
     Session adminSession;
 
-    @Spy
-    PackageRegistry registry = new FSPackageRegistry();
+    @Mock
+    PackageRegistry registry;
 
     @Mock
     ExecutionPlanBuilder builder;


### PR DESCRIPTION
This implements a workaround for https://issues.apache.org/jira/browse/JCRVLT-517 : it is possible that the FSPackageRegistry didn't initialize it's stateCache and the FSPackageRegistry.contains() method, which us used from ExecutionBuilderImpl, doesn't initialize it's cache either - thus dependencies of packages aren't found and the execution plan fails.

The call to FSPackageRegistry.packages() forces the initialization of the stateCache of the registry, and now it works. Thus this can be used with Jackrabbit Vault 3.4.10 as well.

The test failed since the FSPackageRegistry didn't have a home directory set. I just replaced it with a mock, since, as far as I can tell, none of it's funktionality is actually used in the test.